### PR TITLE
feat: Add a --podman argument

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -28,13 +28,15 @@ pub struct DockerImage {
 
 pub struct Runtime<'a> {
     docker_cmd: &'a str,
+    podman: bool,
 }
 
 impl<'a> Runtime<'a> {
     /// Creates a new runtime for interacting with Docker.
-    pub fn new(docker_cmd: &'a str) -> anyhow::Result<Self> {
+    pub fn new(docker_cmd: &'a str, podman: bool) -> anyhow::Result<Self> {
         Ok(Self {
             docker_cmd,
+            podman,
         })
     }
 
@@ -156,7 +158,7 @@ impl<'a> Runtime<'a> {
             command.arg("-p").arg(port);
         }
 
-        if image.variants.contains(TagVariants::GPU) {
+        if image.variants.contains(TagVariants::GPU) && !self.podman {
             command.arg("--gpus=all");
         }
 


### PR DESCRIPTION
This would address the concern in https://github.com/pop-os/tensorman/issues/21, making Tensorman more secure and easier (not needing to have the docker daemon running and be in the `docker` group).

Simple test command:

```
tensorman run --gpu --podman -- python -c "import tensorflow; print(tensorflow.config.list_physical_devices('GPU'))"
```

This requires https://github.com/pop-os/nvidia-container-toolkit/pull/4, which is currently blocked by an upstream issue without an obvious solution.

Then there is the question of whether this should be the default (Podman is packaged in Ubuntu starting in groovy), and how to make it easy to transition. And probably testing it more thoroughly than my test that it is able to see the GPU.