### PR TITLE
feat: enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0.3"
 anyhow = "1.0.19"
+
+[profile.release]
+lto = "fat"


### PR DESCRIPTION
Hi!

I started a discussion about enabling Link-Time Optimization (LTO) across all pop!_os projects to improve their general performance (more compiler optimizations can be done with LTO) and the binary size reduction (LTO usually leads to measurable binary size improvements) here - https://github.com/pop-os/pop/discussions/3386 . In https://github.com/pop-os/pop/discussions/3386#discussioncomment-10909426 was proposed creating PRs into repos with enabling LTO - it's such a PR!

As a reference, I used the `cosmic-comp` Release [profile](https://github.com/pop-os/cosmic-comp/blob/master/Cargo.toml#L116).